### PR TITLE
css: Remove horizontal scrollbar from Twitter feed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -464,6 +464,7 @@ footer .row .span3:last-child {
     height: 300px;
     padding-right: 10px;
     overflow: scroll;
+    overflow-x: hidden;
 }
 #aerogear-twitter li {
     margin-bottom: 10px;


### PR DESCRIPTION
The Twitter feed doesn't scroll sideways so it only adds noise. This commit hides it.
