### PR TITLE
Model property renaming

### DIFF
--- a/docs/specs/aerogear-client-push/index.markdown
+++ b/docs/specs/aerogear-client-push/index.markdown
@@ -41,7 +41,7 @@ The required metadata for an ```Installation```:
 The _AeroGear UnifiedPush Server_ is able to store some user-specific metadata as well:
 
 * **deviceType:** _The device type of the device or the user agent._
-* **mobileOperatingSystem:** _The name of the underlying Operating System._
+* **operatingSystem:** _The name of the underlying Operating System._
 * **osVersion:** _The version of the used Operating System._
 * **alias:** _Application specific alias to identify users with the system. For instance an ```email address``` or a ```username```._
 * **category:** _Used tp apply a "tag". Mainly usful for the SimplePush channel(s)._

--- a/docs/specs/aerogear-push-rest/DeviceRegistration.asciidoc
+++ b/docs/specs/aerogear-push-rest/DeviceRegistration.asciidoc
@@ -20,7 +20,7 @@ JSON Payload:
 {
   "deviceToken" : "someTokenString",
   "deviceType" : "iPad",
-  "mobileOperatingSystem" : "iOS",
+  "operatingSystem" : "iOS",
   "osVersion" : "6.1.2",
   "alias" : "someUsername or email adress...",
   "category" : "football"
@@ -45,7 +45,7 @@ On successful storage of the device related metadata:
   "id":"402880e43fa95bb3013fa960f9ee0002",
   "deviceToken":"someTokenString",
   "deviceType":"iPad",
-  "mobileOperatingSystem":"iOS",
+  "operatingSystem":"iOS",
   "osVersion":"6.1.2",
   "alias":"dude@dude.org",
   "category":"football"

--- a/docs/specs/aerogear-server-push/index.markdown
+++ b/docs/specs/aerogear-server-push/index.markdown
@@ -185,7 +185,7 @@ _Password of the actual variant._
 
 _The device type of the device or the user agent._
 
-- **mobileOperatingSystem:**
+- **operatingSystem:**
 
 _The name of the underlying Operating System._
 
@@ -212,7 +212,7 @@ The server offers an HTTP interfaces to register an _installation_:
         -d '{
           "deviceToken" : "someTokenString",
           "deviceType" : "iPad",
-          "mobileOperatingSystem" : "iOS",
+          "operatingSystem" : "iOS",
           "osVersion" : "6.1.2",
           "alias" : "someUsername or email adress...",
           "category" : "football"


### PR DESCRIPTION
As requested in [AGPUSH-229](jira.jboss.org/browse/AGPUSH-229) this PR covers the documentation/sepc-side of renaming the 'mobileOperatingSystem' field to 'operatingSystem' field.
