### PR TITLE
Reapplying matzew changes

### DIFF
--- a/docs/guides/aerogear-push-js/send-push.asciidoc
+++ b/docs/guides/aerogear-push-js/send-push.asciidoc
@@ -14,13 +14,13 @@ On a command line issue the following _CURL_ command:
 curl -3 -u "{PushApplicationID}:{MasterSecret}"
    -v -H "Accept: application/json" -H "Content-type: application/json"
    -X POST
-   -d '{"simple-push": { "mail":"version=123"}
+   -d '{"simple-push": "version=123"}
    }'
 
 https://SERVER:PORT/CONTEXT/rest/sender
 ----
 
-Notice the _simple-push_ object in the payload. It contains the name of one channel (here _mail_) and its version number. The AeroGear UnifiedPush Server will perform an HTTP PUT update on the SimplePush server. This will cause the SimplePush server to send the push notification to web clients.
+Notice the _simple-push_ object in the payload. It contains a version number. The AeroGear UnifiedPush Server will perform an HTTP PUT update on the SimplePush server. This will cause the SimplePush server to send the push notification to all connected web clients, that belong to the used PushApplication.
 
 [NOTE]
 If you want to send another push notification to that endpoint, make sure you are increasing the version number (e.g. version=124 or version=125 in this case)! Using the same version for that given endpoint does not cause a push notification to be sent to the client.

--- a/docs/specs/aerogear-push-messages/index.markdown
+++ b/docs/specs/aerogear-push-messages/index.markdown
@@ -25,10 +25,7 @@ The UnifiedPush Server allows sending messages to the native and non-native Push
              "someKey":"some value",
              "anotherCustomKey":"some other value"
            },
-           "simple-push": {
-             "SomeCategory":"version=123",
-             "anotherCategory":"version=456"
-           }
+           "simple-push": "version=123"
          }'
 
     https://SERVER:PORT/CONTEXT/rest/sender
@@ -60,8 +57,7 @@ None! The JSON map is submitted as it is, directly to the device. There are no A
 
 #### SimplePush Object
 
-For SimplePush an extra ```simple-push``` object is provided. This key is only used for SimplePush variants. The different versions are submitted to all connected client, that are subscribed on their their matching channels.
-
+For SimplePush an extra ```simple-push``` object is provided. This key is only used for SimplePush variants. The version is submitted to all connected client, that are subscribed on their matching channels.
 
 #### Query component
 

--- a/docs/specs/aerogear-push-rest/Sender.asciidoc
+++ b/docs/specs/aerogear-push-rest/Sender.asciidoc
@@ -28,10 +28,7 @@ Flexible JSON Payload (link:http://aerogear.org/docs/specs/aerogear-push-message
     "someKey":"some value",
     "anotherCustomKey":"some other value"
   },
-  "simple-push": {
-    "SomeCategory":"version=123",
-    "anotherCategory":"version=456"
-  }
+  "simple-push": "version=123"
 }
 ----
 

--- a/docs/specs/aerogear-server-push/index.markdown
+++ b/docs/specs/aerogear-server-push/index.markdown
@@ -252,15 +252,12 @@ Sends a push message to a selected list of devices/clients, or all, based on dif
                "someKey":"some value",
                "anotherCustomKey":"some other value"
            },
-           "simple-push": {
-               "SomeCategory":"version=123",
-               "anotherCategory":"version=456"
-            }
+           "simple-push": "version=123"
         }'
 
     https://SERVER:PORT/context/rest/sender
 
-The ```variants``` is a filter for notifying certain variants (e.g. HR Android, HR iPad etc.) of the PushApplication with the respective IDs. The ```alias``` value is used to identify the desired users, while the ```category``` is more a semantical tag, of a registered ```Installation```. The ```deviceType``` is a filter for notifying only users, running a certain device. The ```ttl``` is supported on GCM/APNs to specify how long the supported networks should try to deliver the notification. The payload (```message``` and ```simple-push```) are standard JSON maps. If platform specific key words (e.g. alert for APNs) are used, they are honored for the specific platform. This transformation is done by the _AeroGear UnifiedPush Server_.
+The ```variants``` is a filter for notifying certain variants (e.g. HR Android, HR iPad etc.) of the PushApplication with the respective IDs. The ```alias``` value is used to identify the desired users, while the ```category``` is more a semantical tag, of a registered ```Installation```. The ```deviceType``` is a filter for notifying only users, running a certain device. The ```ttl``` is supported on GCM/APNs to specify how long the supported networks should try to deliver the notification. The payload (```message``` and ```simple-push```) are standard JSON objects. If platform specific key words (e.g. alert for APNs) are used, they are honored for the specific platform. This transformation is done by the _AeroGear UnifiedPush Server_.
 
 ## Use Cases
 


### PR DESCRIPTION
Due to my bad PR merge without rebase as discussed here:
http://aerogear-dev.1069024.n5.nabble.com/aerogear-dev-Lost-commits-merges-td5243.html

I could not find original commit with SHA-1 5ec383f35a1346e2041e2c05b5273764ebf444ea

So I manually (carefully) reapply the documentation changes.

Please review and I'll merge it.
