### PR TITLE
Add dates to the news

### DIFF
--- a/news/index.md
+++ b/news/index.md
@@ -5,7 +5,7 @@ title: News
 ## AeroGear News
 
 {% for post in site.posts %}
-* [{{post.title}}]({{post.url}})
+*  {{post.date |  date: "%-d %b %Y" }} - [{{post.title}}]({{post.url}})
 {% endfor %}
 
 ## AeroGear Blogs


### PR DESCRIPTION
Is quite annoying when we look for the news on AeroGear and have no idea about when the latest news were posted. This PR aims to fix this.
