### PR TITLE
Add android:name attr to Manifest in android-app guide

### DIFF
--- a/docs/guides/aerogear-push-android/android-app.asciidoc
+++ b/docs/guides/aerogear-push-android/android-app.asciidoc
@@ -188,6 +188,18 @@ Open the _AndroidManifest.xml_ file and below the '<manifest>' entry add the nec
 ...
 ----
 
+Set the application name.  In the '<application>' element add the android:name attribute:
+
+[source,xml]
+----
+<application
+    android:allowBackup="true"
+    android:icon="@drawable/ic_launcher"
+    android:label="@string/app_name"
+    android:theme="@style/AppTheme" 
+    android:name="com.push.pushapplication.PushApplication">
+----
+
 Let's register now AeroGear's Broadcast Receiver that will listen for notifications. Below the '<application>' entry add the following:
 
 [source,xml]


### PR DESCRIPTION
Running the demo android app as per instructions results in a class
cast exception when casting PushApplication to an android.Application.
Setting the android:name attribute in the manifest.xml fixes this.
