### PR TITLE
Updating SimplePush roadmap by moving 0.12.0 to August.

### DIFF
--- a/docs/planning/roadmaps/AeroGearSimplePush.asciidoc
+++ b/docs/planning/roadmaps/AeroGearSimplePush.asciidoc
@@ -16,11 +16,11 @@ AeroGear SimplePush Server Roadmap
 * link:https://issues.jboss.org/browse/AGSMPLPUSH-52[AGSMPLPUSH-52]: Remove synchronization in SockJsSession.
 * link:https://issues.jboss.org/browse/AGSMPLPUSH-54[AGSMPLPUSH-54]: Support notification with no version in the PUT request body.
 
-=== link:https://issues.jboss.org/browse/AGSMPLPUSH-25?jql=project%20%3D%20AGSMPLPUSH%20AND%20fixVersion%20%3D%20%220.12.0%22%20AND%20status%20%3D%20Open%20ORDER%20BY%20priority%20DESC[0.12.0 (July, 2014)]
+=== link:https://issues.jboss.org/browse/AGSMPLPUSH-60?filter=12322070[0.12.0 (August, 2014)]
 * link:https://issues.jboss.org/browse/AGSMPLPUSH-25[AGSMPLPUSH-25]: Verify that we include the latest changes from the SimplePush specification.
 * link:https://issues.jboss.org/browse/AGSMPLPUSH-4[AGSMPLPUSH-4]: Enable batch notifications for SimplePush server.
+* link:https://issues.jboss.org/browse/AGSMPLPUSH-30[AGSMPLPUSH-30]: Add SockJS support to Netty 5
 
 == link:https://issues.jboss.org/browse/AGSMPLPUSH-31?jql=project%20%3D%20AGSMPLPUSH%20AND%20fixVersion%20%3D%20future%20AND%20status%20%3D%20Open%20ORDER%20BY%20priority%20DESC[Future]
-* link:https://issues.jboss.org/browse/AGSMPLPUSH-30[AGSMPLPUSH-30]: Add SockJS support to Netty 5
 * link:https://issues.jboss.org/browse/AGSMPLPUSH-15[AGSMPLPUSH-15]: Investigate scalability for SimplePush Server
 


### PR DESCRIPTION
- also moved the SockJS task to 0.12.0 instead of future.
