### PR TITLE
Fixing install/download instructions

### DIFF
--- a/docs/unifiedpush/ups_userguide/server-installation.asciidoc
+++ b/docs/unifiedpush/ups_userguide/server-installation.asciidoc
@@ -23,32 +23,30 @@ The UnifiedPush Server application is provided in two files: +unifiedpush-server
 
 Download the latest copies of these files using the following links:
 
-* link:http://search.maven.org/#browse%7C1148786796[Download Core Server] - *variants are provided for different application servers:
+* link:https://github.com/aerogear/aerogear-unifiedpush-server/releases/latest[Download UnifiedPush Server Release Bundle] - *variants are provided for different application servers:
 ** For WildFly, +unifiedpush-server-wildfly.war+
 ** For JBoss AS, +unifiedpush-server-as7.war+
-* link:http://search.maven.org/#browse%7C-1163172089[Download Authentication Server]
 
 [[gendbds]]
 === Generate the UnifiedPush Database and Datasource
 The UnifiedPush Server requires an accompanying database in which to store push application, variant and installation details. You can use the database of your choice but the corresponding datasource added to the application server must have JNDI name +java:jboss/datasources/UnifiedPushDS+.
 
-Information is provided here for generating UnifiedPush datasources for several database types. Note that if the intended application server has not previously been used with the chosen database type, additional configuration must also be completed in order to enable the application server to connect to the database. As detailed here, sources and scripts are available to assist with all these processes.  
+Information is provided here for generating UnifiedPush datasources for several database types. Note that if the intended application server has not previously been used with the chosen database type, additional configuration must also be completed in order to enable the application server to connect to the database. As detailed here, sources and scripts are available to assist with all these processes.
 
 ==== H2 Database
 A H2 database is embedded in WildFly and JBoss AS. As demonstrated here, it is simple to configure H2 for use with the UnifiedPush Server with the aid of some provided scripts.
 
-To add the UnifiedPush datasource for the H2 database to the application server, download the link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/unifiedpush-h2-ds.xml[unifiedpush-h2-ds.xml] file and move it to the +/path/to/SERVER_HOME/standalone/deployments+ folder. The UnifiedPush data will be stored in +/path/to/SERVER_HOME/standalone/data/unifiedpush+.
+To add the UnifiedPush datasource for the H2 database to the application server, use the +unifiedpush-h2-ds.xml+ file from the +databases+ folder of the release bundle and move it to the +/path/to/SERVER_HOME/standalone/deployments+ folder. The UnifiedPush data will be stored in +/path/to/SERVER_HOME/standalone/data/unifiedpush+.
 
 Alternatively, you can create the UnifiedPush datasource from scratch and add it to the application server as follows:
 
-. Download the UnifiedPush datasource configuration script for H2, +h2-database-config.cli+, for link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/h2-database-config-wildfly.cli[WildFly] or link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/h2-database-config.cli[JBoss AS].
 . Start the application server
 +
 [source,c]
 ----
 $ ./path/to/SERVER_HOME/bin/standalone.sh
 ----
-. Create and add the UnifiedPush datasource for the H2 database using the application server CLI and downloaded configuration script
+. Create and add the UnifiedPush datasource for the H2 database using the application server CLI and downloaded configuration script, located in the +databases+ directory of the release bundle
 +
 For WildFly:
 +
@@ -69,20 +67,19 @@ You can use a link:http://www.mysql.com/[MySQL] database with the UnifiedPush Se
 
 To complete these prerequisite processes and configure the application server for the UnifiedPush MySQL database, complete the following steps:
 
-. Download the  link:https://github.com/aerogear/aerogear-unifiedpush-server/tree/master/databases/src/main/resources/modules/[+com+ directory], which contains a MySQL module.
-. Copy the downloaded +com+ directory to the application server modules directory
+. Copy the MySQL module, located in the +databases/src/main/resources/modules/com+ directory of the release bundle, to the application server modules directory
 +
 [source,c]
 ----
 $ cp -r /path/to/com /path/to/SERVER_HOME/modules/
----- 
+----
 . Add the MySQL JDBC driver to the application server +mysql+ module
 +
 [source,c]
 ----
 $ mvn dependency:copy -Dartifact=mysql:mysql-connector-java:5.1.18 \
 -DoutputDirectory=/path/to/SERVER_HOME/modules/com/mysql/jdbc/main/
----- 
+----
 . Create the UnifiedPush MySQL database
 +
 [source,c]
@@ -92,14 +89,13 @@ mysql> create database unifiedpush default character set = "UTF8" default collat
 mysql> create user 'unifiedpush'@'localhost' identified by 'unifiedpush';
 mysql> GRANT SELECT,INSERT,UPDATE,ALTER,DELETE,CREATE,DROP ON unifiedpush.* TO 'unifiedpush'@'localhost';h
 ----
-. Download the UnifiedPush datasource configuration script for MySQL, +mysql-database-config.cli+, for link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/mysql-database-config-wildfly.cli[WildFly] or link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/mysql-database-config.cli[JBoss AS].
 . Start the application server
 +
 [source,c]
 ----
 $ ./path/to/SERVER_HOME/bin/standalone.sh
 ----
-. Configure the application server to use the MySQL driver and create and add the UnifiedPush datasource for the MySQL database using the application server CLI and downloaded configuration script
+. Configure the application server to use the MySQL driver and create and add the UnifiedPush datasource for the MySQL database using the application server CLI and downloaded configuration script, located in the +databases+ directory of the release bundle
 +
 For WildFly:
 +
@@ -120,20 +116,19 @@ You can use a link:http://www.postgresql.org/[PostgreSQL] database with the Unif
 
 To complete these prerequisite processes and configure the application server for the UnifiedPush PostgreSQL database, complete the following steps:
 
-. Download the  link:https://github.com/aerogear/aerogear-unifiedpush-server/tree/master/databases/src/main/resources/modules/[+org+ directory], which contains a PostgreSQL module.
-. Copy the downloaded +org+ directory to the application server modules directory
+. Copy the PostgreSQL module, located in the +databases/src/main/resources/modules/org+ directory of the release bundle, to the application server modules directory
 +
 [source,c]
 ----
 $ cp -r /path/to/org /path/to/SERVER_HOME/modules/
----- 
+----
 . Add the PostgreSQL JDBC driver to the application server +postgresql+ module
 +
 [source,c]
 ----
 $ mvn dependency:copy -Dartifact=org.postgresql:postgresql:9.2-1004-jdbc41 \
 -DoutputDirectory=/Path/to/JBossAS/modules/org/postgresql/main/
----- 
+----
 . Create the UnifiedPush PostgreSQL database
 +
 [source,c]
@@ -149,14 +144,13 @@ psql> GRANT ALL PRIVILEGES ON DATABASE unifiedpush to unifiedpush;
 ----
 host    all             unifiedpush     127.0.0.1/32            md5
 ----
-. Download the UnifiedPush datasource configuration script for PostgreSQL, +postgresql-database-config.cli+, for link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/postgresql-database-config-wildfly.cli[WildFly] or link:https://raw.githubusercontent.com/aerogear/aerogear-unifiedpush-server/master/databases/postgresql-database-config.cli[JBoss AS].
 . Start the application server
 +
 [source,c]
 ----
 $ ./path/to/SERVER_HOME/bin/standalone.sh
 ----
-. Configure the application server to use the PostgreSQL driver and create and add the UnifiedPush datasource for the PostgreSQL database using the application server CLI and downloaded configuration script
+. Configure the application server to use the PostgreSQL driver and create and add the UnifiedPush datasource for the PostgreSQL database using the application server CLI and downloaded configuration script, located in the +databases+ directory of the release bundle
 +
 For WildFly:
 +


### PR DESCRIPTION
We now have a downloadable release bundle:
https://github.com/aerogear/aerogear-unifiedpush-server/releases/lates

This contains all required files:
- server WAR files
- database CLIs
- XML (for H2)
- modules for PostgreSQL and MYSQL

Updated the instructions to reflect this new download archive 
