### PR TITLE
Adding OAuth2 table, based on release blog

### DIFF
--- a/OAuth2/index.markdown
+++ b/OAuth2/index.markdown
@@ -7,6 +7,14 @@ title: AeroGear OAuth2
 
 Support of OAuth2 for [Keycloak](http://keycloak.jboss.org/), Google and Facebook on our Android, iOS, Windows and Cordova platforms.
 
+| Flows          | Android | iOS | JavaScript | Cordova | Windows Phone |
+|:---------------------:|:-------:|:---:|:----------:|:-------:|:-------------:|
+|[Implicit grant flow](https://tools.ietf.org/html/rfc6749#section-4.2)|**-**|**-**|**-**|_soon_|**-**|
+|[Refresh access tokens](https://tools.ietf.org/html/rfc6749#section-4.3)|&#10004;|&#10004;|**-**|**-**|**-**|
+|[Token revocation](http://tools.ietf.org/html/rfc7009#section-2)|**-**|&#10004;|**-**|**-**|**-**|
+|[Resource owner password credentials grant](https://tools.ietf.org/html/rfc6749#section-4.3) |**-**|_soon_|**-**|**-**|**-**|
+|[Authorization Code Grant](https://tools.ietf.org/html/rfc6749#section-4.1)|&#10004;|&#10004;|**-**|**-**|**-**|
+
 ## Roadmap
 
 The AeroGear OAuth2 effort started out of a POC and we are now moving towards a first release. 


### PR DESCRIPTION
Based on our announcement last week, here is the same table.

Minor note: rendering looks better on github, than on our own hosted Jekyyl site ;-)