### PR TITLE
adds layout for news posts

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -2,11 +2,11 @@
       <li>
         {% if page.section == 'guides' %}
           <a href="{{ site.baseurl }}/getstarted/guides/">Guides</a>
-        {% else if page.section == 'modules' %}
+        {% elsif page.section == 'modules' %}
           <a href="{{ site.baseurl }}/modules//">Modules</a>
-        {% else if page.section == 'news' %}
+        {% elsif page.section == 'news' %}
           <a href="{{ site.baseurl }}/news/">News</a>
-        {% else if page.section == 'community' %}
+        {% elsif page.section == 'community' %}
           <a href="{{ site.baseurl }}/community/">Community</a>
         {% endif %}
       </li>

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,14 @@
+    <ol class="breadcrumb" style="margin:0">
+      <li>
+        {% if page.section == 'guides' %}
+          <a href="{{ site.baseurl }}/getstarted/guides/">Guides</a>
+        {% else if page.section == 'modules' %}
+          <a href="{{ site.baseurl }}/modules//">Modules</a>
+        {% else if page.section == 'news' %}
+          <a href="{{ site.baseurl }}/news/">News</a>
+        {% else if page.section == 'community' %}
+          <a href="{{ site.baseurl }}/community/">Community</a>
+        {% endif %}
+      </li>
+      <li class="active">{{page.title}}</li>
+    </ol>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html>
+<head>
+{% include header.html %}
+</head>
+
+<body>    
+
+{% include navigation.html %}
+
+{% include jboss-dropup.html %}
+
+<section class="main-banner">
+  <div class="container">
+    {% include inner-header.html %}
+  </div><!-- container -->
+</section> <!-- main banner -->
+
+
+<section class="{{ page.section }}">
+  
+  <div class="container">
+     {% include breadcrumbs.html %}
+  </div><!-- container -->
+
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-8 col-md-offset-2 post">
+
+        <h1>{{ page.title }}</h1>
+          
+        <div class="media">
+          <div class="media-left">
+            <img src="https://avatars1.githubusercontent.com/u/1395710" />
+          </div>
+          <div class="media-body">
+            <p class="article-subtitle">by
+              <span itemprop="author">
+                Bruno Oliveira
+              </span>
+            </p>
+            <p class="article-date" itemprop="datePublished" content="{{post.date |  date: "%Y-%m-%d" }}">
+              posted on 5 Feb 2015
+            </p>
+          </div>
+        </div>        
+
+        {{ content }}
+        
+        
+        <ul class="list-inline article-extra-info">
+
+          <li class="article-extra-info-module">
+            <strong>module:</strong>
+            <a href="#">
+              <i class="fa fa-shield"></i>
+              Aerogear<strong>Security</strong>
+            </a>
+          </li>        
+          
+          <li class="article-extra-info-platform">
+            <strong>platform:</strong>
+              <a href="#">
+                Android
+              </a>
+          </li>
+          
+          <li class="article-extra-info-release">
+            <strong>releases:</strong> 
+              <a href="#">
+                1.2
+              </a>
+          </li>
+        </ul>
+    
+        <div class="tag-cloud">
+          <a href="#"><i class="fa fa-tag"></i> ups</a>
+          <a href="#"><i class="fa fa-tag"></i> javascript</a>
+          <a href="#"><i class="fa fa-tag"></i> consoleUI</a>
+          <a href="#"><i class="fa fa-tag"></i> tagname</a>
+          <a href="#"><i class="fa fa-tag"></i> java</a>
+        </div>
+        
+
+      </div><!-- col 8 -->
+    </div><!-- row -->
+  </div><!-- container -->
+</section>
+
+
+
+{% include footer.html %}
+
+{% include js.html %}
+
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,21 +20,7 @@
 <section class="{{ page.section }}">
   
   <div class="container">
-    <ol class="breadcrumb" style="margin:0">
-     
-      <li>
-        {% if page.section == 'guides' %}
-          <a href="{{ site.baseurl }}/getstarted/guides/">Guides</a>
-        {% else if page.section == 'modules' %}
-          <a href="{{ site.baseurl }}/modules//">Modules</a>
-        {% else if page.section == 'news' %}
-          <a href="{{ site.baseurl }}/news/">News</a>
-        {% else if page.section == 'community' %}
-          <a href="{{ site.baseurl }}/community/">Community</a>
-        {% endif %}
-      </li>
-      <li class="active">{{page.title}}</li>
-    </ol>
+     {% include breadcrumbs.html %}
   </div><!-- container -->
 
 

--- a/_posts/2012-10-24-aerogear-1.0.0.M6-is-out.md
+++ b/_posts/2012-10-24-aerogear-1.0.0.M6-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.0.0.M6 is out!
 author: qmx

--- a/_posts/2012-12-20-aerogear-1.0.0.M7-is-out.md
+++ b/_posts/2012-12-20-aerogear-1.0.0.M7-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.0.0.M7 is out!
 sub-section-title: News

--- a/_posts/2013-01-30-aerogear-1.0.0.M8-is-out.md
+++ b/_posts/2013-01-30-aerogear-1.0.0.M8-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.0.0.M8 is out!
 sub-section-title: News

--- a/_posts/2013-03-04-aerogear-1.0.0.CR1-is-out.md
+++ b/_posts/2013-03-04-aerogear-1.0.0.CR1-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.0.0.CR1 is out!
 sub-section-title: News

--- a/_posts/2013-03-28-aerogear-1.0.0-is-out.md
+++ b/_posts/2013-03-28-aerogear-1.0.0-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.0.0 is out!
 sub-section-title: News

--- a/_posts/2013-08-19-aerogear-1.1.0-is-out.md
+++ b/_posts/2013-08-19-aerogear-1.1.0-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.1.0 is out!
 sub-section-title: News

--- a/_posts/2013-12-02-aerogear-1.2.0-is-out.md
+++ b/_posts/2013-12-02-aerogear-1.2.0-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear 1.2.0 is out!
 author: abstractj

--- a/_posts/2014-08-27-aerogear-push-1.0.0-is-out.md
+++ b/_posts/2014-08-27-aerogear-push-1.0.0-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear Mobile Push 1.0.0 is out!
 author: matzew

--- a/_posts/2014-09-17-aerogear-push-1.0.1-is-out.md
+++ b/_posts/2014-09-17-aerogear-push-1.0.1-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear Mobile Push 1.0.1 is out!
 author: sebastienblanc

--- a/_posts/2014-11-06-aerogear-push-1.0.2-is-out.md
+++ b/_posts/2014-11-06-aerogear-push-1.0.2-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear UnifiedPush Server 1.0.2 is out!
 author: matzew

--- a/_posts/2014-11-11-aerogear-feedhenry-integration.md
+++ b/_posts/2014-11-11-aerogear-feedhenry-integration.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: FeedHenry meets AeroGear UnifiedPush Server!
 author: matzew

--- a/_posts/2014-11-12-aerogear-feedhenry-devoxx-demo.md
+++ b/_posts/2014-11-12-aerogear-feedhenry-devoxx-demo.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: Devoxx keynote Feedhenry AeroGear demo
 author: matzew

--- a/_posts/2014-11-20-aerogear-unified-push-xpaas.md
+++ b/_posts/2014-11-20-aerogear-unified-push-xpaas.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: Red Hat JBoss Unified Push Server and xPaaS
 author: matzew

--- a/_posts/2014-12-03-aerogear-unified-push-alpha1-is-out.md
+++ b/_posts/2014-12-03-aerogear-unified-push-alpha1-is-out.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: UnifiedPush Server 1.1.0-alpha.1 with Windows Push is out !
 author: sebastienblanc

--- a/_posts/2015-01-19-aerogear-android-2.0.0.md
+++ b/_posts/2015-01-19-aerogear-android-2.0.0.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear Android 2.0.0 is out !
 author: secondsun

--- a/_posts/2015-01-23-aerogear-push-sdk.md
+++ b/_posts/2015-01-23-aerogear-push-sdk.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear iOS Push-SDK for Swift v1.0
 author: corinnekrych

--- a/_posts/2015-01-30-aerogear-ios-2.1.md
+++ b/_posts/2015-01-30-aerogear-ios-2.1.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 section: news
 title: AeroGear iOS SDK v2.1 is out !
 author: corinnekrych

--- a/_posts/2015-02-05-aerogear-oauth2.md
+++ b/_posts/2015-02-05-aerogear-oauth2.md
@@ -1,11 +1,12 @@
 ---
-layout: post
+layout: news
 section: news
 title: OAuth2 support on AeroGear
 author: abstractj
 module: security
 ---
 
+	
 
 Fasten your seatbelts, because today we are pleased to announce the official availability of our SDKs for OAuth2.
 

--- a/css/styles.less
+++ b/css/styles.less
@@ -304,6 +304,20 @@ h1{
       margin-right: -10%;  
     }
   }
+
+
+    
+  .media{
+    margin-bottom: 20px;
+  }
+  .article-extra-info{
+    border-top: 1px solid @gray-divider;
+    margin-top: 20px;
+    padding-top: 10px;
+    .article-extra-info-module, .article-extra-info-platform, .article-extra-info-release{
+      float: left;
+    }
+  }
 }
 
 table{
@@ -829,10 +843,13 @@ display: none;
     border: none; padding-top: 0; margin-top: 0;
     &.article{margin-bottom: 20px;}
   }
+}
+
+  
   .article-title,
   .article-subtitle,
   .article-date{
-    margin: 0 0 0px 0;
+    margin: 0 0 0px 0!important;
   }
   
   .article-twiter{
@@ -870,6 +887,8 @@ display: none;
   
   .article-header{
     margin-bottom: 5px;
+  }
+
     span[itemprop="author"]{
 //      background: red;
       font-weight: @font-weight-bold;
@@ -883,7 +902,7 @@ display: none;
         max-width: 34px;
       }
     }
-  }
+  
   .article-icon{
     background: @gray-divider;
     color: @gray-subtitle;
@@ -902,7 +921,6 @@ display: none;
     padding-right: 40px;
   }
   
-}
 
 
 .tag-cloud{
@@ -1441,3 +1459,20 @@ input.code {
 //  font-size: 0.8em;
 //  color: gray;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/css/styles.less
+++ b/css/styles.less
@@ -1459,20 +1459,3 @@ input.code {
 //  font-size: 0.8em;
 //  color: gray;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
New layout for news posts called `news`. 
It has more information:
- the author's name and avatar
- date of posting
- module name and logo
- platform
- tags
