### PR TITLE
automatic TOC generation + changes to Push Module page

### DIFF
--- a/_layouts/landing-page.html
+++ b/_layouts/landing-page.html
@@ -16,13 +16,17 @@
   </div><!-- container -->
 </section> <!-- main banner -->
 
-
 <section class="{{ page.section }}">
 
 
   <div class="container">
     <div class="row">
-      <div class="col-md-8 col-md-offset-2 post">
+      <div class="col-md-3 sidebar">
+        <div class="submenu">
+          {{ content | toc_generate }}
+        </div><!-- sidebar -->
+      </div><!-- col -->
+      <div class="col-md-9 post">
         {{ content }}
       </div><!-- col 8 -->
     </div><!-- row -->

--- a/_plugins/tocGenerator.rb
+++ b/_plugins/tocGenerator.rb
@@ -1,0 +1,117 @@
+require 'nokogiri'
+
+module Jekyll
+  module TOCGenerator
+    TOGGLE_HTML = '<div id="toctitle"><h2>%1</h2>%2</div>'
+    TOC_CONTAINER_HTML = '<div id="toc-container"><table class="toc" id="toc"><tbody><tr><td>%1<ul>%2</ul></td></tr></tbody></table></div>'
+    HIDE_HTML = '<span class="toctoggle">[<a id="toctogglelink" class="internal" href="#">%1</a>]</span>'
+
+   def toc_generate(html)
+        # No Toc can be specified on every single page
+        # For example the index page has no table of contents
+        no_toc = @context.environments.first["page"]["noToc"] || false;
+
+        if no_toc
+            return html
+        end
+
+        config = @context.registers[:site].config
+        # Minimum number of items needed to show TOC, default 0 (0 means no minimum)
+        min_items_to_show_toc = config["minItemsToShowToc"] || 0
+
+        anchor_prefix = config["anchorPrefix"] || 'tocAnchor-'
+
+        # Text labels
+        contents_label = config["contentsLabel"] || 'Contents'
+        hide_label = config["hideLabel"] || 'hide'
+        show_label = config["showLabel"] || 'show'
+        show_toggle_button = config["showToggleButton"]
+
+        toc_html = ''
+        toc_level = 1
+        toc_section = 1
+        item_number = 1
+        level_html = ''
+
+        doc = Nokogiri::HTML(html)
+
+        # Find H1 tag and all its H2 siblings until next H1
+        doc.css('h1').each do |h1|
+            # TODO This XPATH expression can greatly improved
+            ct  = h1.xpath('count(following-sibling::h1)')
+            h2s = h1.xpath("following-sibling::h2[count(following-sibling::h1)=#{ct}]")
+
+            level_html = '';
+            inner_section = 0;
+
+            h2s.map.each do |h2|
+                inner_section += 1;
+                anchor_id = anchor_prefix + toc_level.to_s + '-' + toc_section.to_s + '-' + inner_section.to_s
+                h2['id'] = "#{anchor_id}"
+
+                level_html += create_level_html(anchor_id,
+                    toc_level + 1,
+                    toc_section + inner_section,
+                    item_number.to_s + '.' + inner_section.to_s,
+                    h2.text,
+                    '')
+            end
+            if level_html.length > 0
+                level_html = '<ul>' + level_html + '</ul>';
+            end
+            anchor_id = anchor_prefix + toc_level.to_s + '-' + toc_section.to_s;
+            h1['id'] = "#{anchor_id}"
+
+            toc_html += create_level_html(anchor_id,
+                toc_level,
+                toc_section,
+                item_number,
+                h1.text,
+                level_html);
+
+            toc_section += 1 + inner_section;
+            item_number += 1;
+        end
+
+        # for convenience item_number starts from 1
+        # so we decrement it to obtain the index count
+        toc_index_count = item_number - 1
+
+        if toc_html.length > 0
+            hide_html = '';
+            if (show_toggle_button)
+                hide_html = HIDE_HTML.gsub('%1', hide_label)
+            end
+
+            if min_items_to_show_toc <= toc_index_count
+                replaced_toggle_html = TOGGLE_HTML
+                    .gsub('%1', contents_label)
+                    .gsub('%2', hide_html);
+                toc_table = TOC_CONTAINER_HTML
+                    .gsub('%1', replaced_toggle_html)
+                    .gsub('%2', toc_html);
+                doc.css('body').children.before(toc_table)
+            end
+            doc.css('body').children.to_xhtml(indent:3, indent_text:" ")
+        else
+            return html
+        end
+   end
+
+private
+
+    def create_level_html(anchor_id, toc_level, toc_section, tocNumber, tocText, tocInner)
+        link = '<a href="#%1"><span class="tocnumber">%2</span> <span class="toctext">%3</span></a>%4'
+            .gsub('%1', anchor_id.to_s)
+            .gsub('%2', tocNumber.to_s)
+            .gsub('%3', tocText)
+            .gsub('%4', tocInner ? tocInner : '');
+        '<li class="toc_level-%1 toc_section-%2">%3</li>'
+            .gsub('%1', toc_level.to_s)
+            .gsub('%2', toc_section.to_s)
+            .gsub('%3', link)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::TOCGenerator)

--- a/css/styles.less
+++ b/css/styles.less
@@ -259,15 +259,15 @@ margin-top: 0;
 //breadcrumbs ==================================================================
 
 .breadcrumb{
-  margin: 0;
+  margin-bottom: 20px;
 }
 
 //general stuff ==================================================================
 
 .post{
-margin-top: 20px;
 h1{
-  font-size: @font-size-h2
+  font-size: @font-size-h2;
+  margin-top: 0;
 }
   h1,h2,h3,h4,h5,h6{
     line-height: @line-height-large;

--- a/docs/specs/index.markdown
+++ b/docs/specs/index.markdown
@@ -46,7 +46,7 @@ span.version {
 
 <h2 class="section-header" id="push"><i class="fa fa-paper-plane"></i> AeroGear<strong>Push</strong> Docs</h2>
 
-<h4>UnifiedPush</h4>
+<h4 id="unifiedpush">UnifiedPush</h4>
 
 * [UnifiedPush RESTful APIs - stable](aerogear-unifiedpush-rest-1.0.x/overview-index.html)
 * [UnifiedPush RESTful APIs - development](aerogear-unifiedpush-rest/overview-index.html)

--- a/getstarted/downloads/index.html
+++ b/getstarted/downloads/index.html
@@ -126,11 +126,11 @@ section: getstarted
 
   <hr> <!-- ====================================================== -->
 
-  <h3><i class="fa fa-send-o"></i> UnifiedPush Server</h3>
+  <h3 id="unifiedpush"><i class="fa fa-send-o"></i> UnifiedPush Server</h3>
 
   <p>
-    <a href="https://developers.openshift.com/en/xpaas-unified-push.html#getting-started" class="btn btn-primary-inverse btn-lg"><i class="fa fa-cloud"></i> Run on OpenShift</a>
-    <a href="https://registry.hub.docker.com/u/aerogear/unifiedpush-wildfly/" class="btn btn-primary-inverse btn-lg"><i class="fa fa-cloud"></i> Run as Docker container</a>
+    <a href="https://developers.openshift.com/en/xpaas-unified-push.html#getting-started" class="btn btn-primary btn-lg"><i class="fa fa-cloud"></i> Run on OpenShift</a>
+    <a href="https://registry.hub.docker.com/u/aerogear/unifiedpush-wildfly/" class="btn btn-primary btn-lg"><i class="fa fa-cloud"></i> Run as Docker container</a>
   </p>
 
   <p>

--- a/push/index.html
+++ b/push/index.html
@@ -16,7 +16,7 @@ sub-section-title: AeroGear Push
     <a href="/getstarted/guides/#push" class="btn btn-primary btn-sm"><i class="fa fa-book"></i> Guides</a>
     <a href="/getstarted/demos/" class="btn btn-primary btn-sm"><i class="fa fa-cogs"></i> Demos</a>
     <a href="/docs/specs/#push" class="btn btn-primary btn-sm"><i class="fa fa-file-text-o"></i> Documentation</a>
-    <a href="https://github.com/aerogear/?query=push" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repos</a>
+    <a href="https://github.com/aerogear/?query=push" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repositories</a>
   </p>
 
   <h3>Supported Technologies</h3>
@@ -35,7 +35,14 @@ sub-section-title: AeroGear Push
 <article>
   <h2 id="unifiedpush"><i class="fa fa-send-o"></i> Unified<strong>Push</strong> Server</h2>
 
-  <p>The AeroGear UnifiedPush Server is server that allows sending native push messages to different mobile operating systems, such as Android, iOS, Windows or Firefox OS/SimplePush.</p>
+  <p class="alt">The AeroGear UnifiedPush Server is server that allows sending native push messages to different mobile operating systems, such as Android, iOS, Windows or Firefox OS/SimplePush.</p>
+
+  <p>
+    <a href="/getstarted/downloads/#unifiedpush" class="btn btn-primary-inverse"><i class="fa fa-hand-o-right"></i> Get started with UnifiedPush Server</a>
+    <a href="/docs/unifiedpush/ups_userguide/" class="btn btn-primary btn-sm"><i class="fa fa-book"></i> Guide</a>
+    <a href="/docs/specs/#unifiedpush" class="btn btn-primary btn-sm"><i class="fa fa-file-text-o"></i> API Documentation</a>
+    <a href="https://github.com/aerogear/aerogear-unifiedpush-server/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repo</a>
+  </p>
 
   <h4>See it in Action</h4>
 
@@ -45,16 +52,11 @@ sub-section-title: AeroGear Push
 
   <h4>Getting started</h4>
 
-  <p>To get started with the UnifiedPush Server checkout one of our <a href="/getstarted/downloads/#push" class="btn btn-primary-inverse"><i class="fa fa-hand-o-right"></i> Releases</a></p>
+  <p>To get started with the UnifiedPush Server checkout one of our <a href="/getstarted/downloads/#push">Releases</a>.</p>
 
-  <!--<ul>-->
-    <!--<li><a href="https://github.com/aerogear/aerogear-unifiedpush-server/releases/tag/1.0.2">1.0.2 (stable)</a></li>-->
-    <!--<li><a href="https://github.com/aerogear/aerogear-unifiedpush-server/releases/tag/1.0.2">1.1.0-alpha.1</a></li>-->
-  <!--</ul>-->
+  <p>For more information please checkout out our detailed <a href="/getstarted/guides/#unifiedpush">Guides</a> and <a href="/docs/specs/#push">Documentation</a>.</p>
 
-  <p>For more information please checkout out our detailed <a href="/getstarted/guides/#push" class="btn btn-primary btn-sm"><i class="fa fa-book"></i> Guides</a> and <a href="/docs/specs/#push" class="btn btn-primary btn-sm"><i class="fa fa-file-text-o"></i> Documentation</a></p>
-
-  <p>Feel free browse the source or fork the <a href="https://github.com/aerogear/aerogear-unifiedpush-server/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repo</a></p>
+  <p>Feel free browse the source or fork the <a href="https://github.com/aerogear/aerogear-unifiedpush-server/">GitHub Repo</a>.</p>
 </article>
 
 <!---------------------------------------------------->
@@ -63,32 +65,42 @@ sub-section-title: AeroGear Push
 
   <h2 id="simplepush"><i class="fa fa-cogs"></i> Simple<strong>Push</strong> Server</h2>
 
-  <p>Our SimplePush Server represents an implementation of <a href="https://wiki.mozilla.org/WebAPI/SimplePush">Mozilla's SimplePush</a>, which is based on-top of WebSocket. It was created for Push Notifications delivery on FirefoxOS, but can also be used for different use-cases, like for the Internet-of-Things.</p>
+  <p class="alt">Our SimplePush Server represents an implementation of <a href="https://wiki.mozilla.org/WebAPI/SimplePush">Mozilla's SimplePush</a>, which is based on-top of WebSocket. It was created for Push Notifications delivery on FirefoxOS, but can also be used for different use-cases, like for the Internet-of-Things.</p>
+
+  <p>
+    <a href="/getstarted/downloads/#simplepush" class="btn btn-primary-inverse"><i class="fa fa-hand-o-right"></i> Get started with SimplePush Server</a>
+    <a href="https://github.com/aerogear/aerogear-js-cookbook/tree/master/simplepush-example" class="btn btn-primary btn-sm"><i class="fa fa-cogs"></i> Quickstart</a>
+    <a href="https://github.com/aerogear/aerogear-simplepush-server/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repo</a>
+  </p>
 
   <h4>See it in Action</h4>
   <p>Best way to see our SimplePush Server in action is using our <a href="https://github.com/aerogear/aerogear-js-cookbook/tree/master/simplepush-example">Quickstart example</a>.</p>
 
   <h4>Get Started</h4>
 
-  <p>To get started with the SimplePush Server checkout the last <a href="/getstarted/downloads/#simplepush" class="btn btn-primary-inverse"><i class="fa fa-hand-o-right"></i> Release</a></p>
+  <p>To get started with the SimplePush Server checkout the last <a href="/getstarted/downloads/#simplepush">release</a>.</p>
 
 </article>
 
 <!---------------------------------------------------->
 
 <article>
-  <h2 id="webpush"><i class="fa fa-flask"></i> Web<strong>Push</strong> Server</h2>
+
+  <h2 id="webpush"><i class="fa fa-flask"></i> Web<strong>Push</strong> Server <sub><span class="label label-warning">Experimental</span></sub></h2>
   <p>The <a href="https://tools.ietf.org/html/draft-thomson-webpush-http2">WebPush Specification</a> is based on HTTP2 and currently in an early state. The AeroGear team sees it as the successor of SimplePush.</p>
+  <p>
+    <a href="https://github.com/aerogear/aerogear-webpush-server/" class="btn btn-primary-inverse"><i class="fa fa-github-alt"></i> GitHub Repo</a>
+  </p>
 
   <h4>Getting started</h4>
-  <p>To get started with the WebPush Server fork the <a href="https://github.com/aerogear/aerogear-webpush-server" class="btn btn-primary-inverse"><i class="fa fa-github-alt"></i> GitHub Repo</a></p>
+  <p>To get started with the WebPush Server fork the <a href="https://github.com/aerogear/aerogear-webpush-server">GitHub Repo</a>.</p>
 </article>
 
 <!---------------------------------------------------->
 
 <article>
   <h2 id="roadmap"><i class="fa fa-road"></i> RoadMap</h2>
-  <p>Upcoming releases of these three push servers are tracked in our project <a href="/docs/planning" class="btn btn-primary btn-sm"><i class="fa fa-road"></i> RoadMap</a>.</p>
+  <p>Upcoming releases of these three push servers are tracked in our project <a href="/docs/planning" class="btn btn-primary btn-sm"><i class="fa fa-road"></i> RoadMap</a></p>
 </article>
 
 
@@ -96,5 +108,5 @@ sub-section-title: AeroGear Push
 
 <article>
   <h2 id="get-involved"><i class="fa fa-users"></i> Get Involved</h2>
-  <p>If you are interested, feel free to fork the <a href="https://github.com/aerogear" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> Repositories</a> and get your hands dirty. Also, feel free to reach out to us if you have any <a href="/community/#contact" class="btn btn-primary btn-sm"><i class="fa fa-question"></i> Questions</a></p>
+  <p>If you are interested, feel free to fork the <a href="https://github.com/aerogear" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> Repositories</a> and get your hands dirty. Also, feel free to reach out to us if you have any <a href="/community/#contact" class="btn btn-primary btn-sm"><i class="fa fa-users"></i> Questions</a></p>
 </article>

--- a/push/index.html
+++ b/push/index.html
@@ -6,9 +6,9 @@ breadcrumbs-url: /modules/
 sub-section-title: AeroGear Push
 ---
 
-<article class="push">
 
   <h1><i class="fa fa-paper-plane"></i> AeroGear<strong>Push</strong></h1>
+
   <p class="alt">Send push notifications to any device, regardless of platform or network.</p>
 
   <p>
@@ -28,11 +28,7 @@ sub-section-title: AeroGear Push
     <li><a href="#webpush">WebPush Server</a></li>
   </ul>
 
-</article><!-- feature -->
 
-<!---------------------------------------------------->
-
-<article>
   <h2 id="unifiedpush"><i class="fa fa-send-o"></i> Unified<strong>Push</strong> Server</h2>
 
   <p class="alt">The AeroGear UnifiedPush Server is server that allows sending native push messages to different mobile operating systems, such as Android, iOS, Windows or Firefox OS/SimplePush.</p>
@@ -44,25 +40,21 @@ sub-section-title: AeroGear Push
     <a href="https://github.com/aerogear/aerogear-unifiedpush-server/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repo</a>
   </p>
 
-  <h4>See it in Action</h4>
+  <h3>See it in Action</h3>
 
   <p>To see it in action, watch the screencast below:</p>
 
   <p><center><iframe width="560" height="315" src="//www.youtube.com/embed/-hh-sEesocs" frameborder="0" allowfullscreen></iframe></center></p>
 
-  <h4>Getting started</h4>
+  <h3>Getting started</h3>
 
   <p>To get started with the UnifiedPush Server checkout one of our <a href="/getstarted/downloads/#push">Releases</a>.</p>
 
   <p>For more information please checkout out our detailed <a href="/getstarted/guides/#unifiedpush">Guides</a> and <a href="/docs/specs/#push">Documentation</a>.</p>
 
   <p>Feel free browse the source or fork the <a href="https://github.com/aerogear/aerogear-unifiedpush-server/">GitHub Repo</a>.</p>
-</article>
 
-<!---------------------------------------------------->
-
-<article>
-
+  
   <h2 id="simplepush"><i class="fa fa-cogs"></i> Simple<strong>Push</strong> Server</h2>
 
   <p class="alt">Our SimplePush Server represents an implementation of <a href="https://wiki.mozilla.org/WebAPI/SimplePush">Mozilla's SimplePush</a>, which is based on-top of WebSocket. It was created for Push Notifications delivery on FirefoxOS, but can also be used for different use-cases, like for the Internet-of-Things.</p>
@@ -73,40 +65,28 @@ sub-section-title: AeroGear Push
     <a href="https://github.com/aerogear/aerogear-simplepush-server/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> GitHub Repo</a>
   </p>
 
-  <h4>See it in Action</h4>
+  <h3>See it in Action</h3>
   <p>Best way to see our SimplePush Server in action is using our <a href="https://github.com/aerogear/aerogear-js-cookbook/tree/master/simplepush-example">Quickstart example</a>.</p>
 
-  <h4>Get Started</h4>
+  <h3>Get Started</h3>
 
   <p>To get started with the SimplePush Server checkout the last <a href="/getstarted/downloads/#simplepush">release</a>.</p>
 
-</article>
 
-<!---------------------------------------------------->
-
-<article>
-
+  
   <h2 id="webpush"><i class="fa fa-flask"></i> Web<strong>Push</strong> Server <sub><span class="label label-warning">Experimental</span></sub></h2>
   <p>The <a href="https://tools.ietf.org/html/draft-thomson-webpush-http2">WebPush Specification</a> is based on HTTP2 and currently in an early state. The AeroGear team sees it as the successor of SimplePush.</p>
   <p>
     <a href="https://github.com/aerogear/aerogear-webpush-server/" class="btn btn-primary-inverse"><i class="fa fa-github-alt"></i> GitHub Repo</a>
   </p>
 
-  <h4>Getting started</h4>
+  <h3>Getting started</h3>
   <p>To get started with the WebPush Server fork the <a href="https://github.com/aerogear/aerogear-webpush-server">GitHub Repo</a>.</p>
-</article>
 
-<!---------------------------------------------------->
-
-<article>
+  
   <h2 id="roadmap"><i class="fa fa-road"></i> RoadMap</h2>
   <p>Upcoming releases of these three push servers are tracked in our project <a href="/docs/planning" class="btn btn-primary btn-sm"><i class="fa fa-road"></i> RoadMap</a></p>
-</article>
 
-
-<!---------------------------------------------------->
-
-<article>
-  <h2 id="get-involved"><i class="fa fa-users"></i> Get Involved</h2>
+    <h2 id="get-involved"><i class="fa fa-users"></i> Get Involved</h2>
   <p>If you are interested, feel free to fork the <a href="https://github.com/aerogear" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> Repositories</a> and get your hands dirty. Also, feel free to reach out to us if you have any <a href="/community/#contact" class="btn btn-primary btn-sm"><i class="fa fa-users"></i> Questions</a></p>
-</article>
+

--- a/push/index.html
+++ b/push/index.html
@@ -32,8 +32,8 @@ sub-section-title: AeroGear Push
 
 <!---------------------------------------------------->
 
-<article id="unifiedpush">
-  <h2><i class="fa fa-send-o"></i> Unified<strong>Push</strong> Server</h2>
+<article>
+  <h2 id="unifiedpush"><i class="fa fa-send-o"></i> Unified<strong>Push</strong> Server</h2>
 
   <p>The AeroGear UnifiedPush Server is server that allows sending native push messages to different mobile operating systems, such as Android, iOS, Windows or Firefox OS/SimplePush.</p>
 
@@ -59,9 +59,9 @@ sub-section-title: AeroGear Push
 
 <!---------------------------------------------------->
 
-<article id="simplepush">
+<article>
 
-  <h2><i class="fa fa-cogs"></i> Simple<strong>Push</strong> Server</h2>
+  <h2 id="simplepush"><i class="fa fa-cogs"></i> Simple<strong>Push</strong> Server</h2>
 
   <p>Our SimplePush Server represents an implementation of <a href="https://wiki.mozilla.org/WebAPI/SimplePush">Mozilla's SimplePush</a>, which is based on-top of WebSocket. It was created for Push Notifications delivery on FirefoxOS, but can also be used for different use-cases, like for the Internet-of-Things.</p>
 
@@ -76,8 +76,8 @@ sub-section-title: AeroGear Push
 
 <!---------------------------------------------------->
 
-<article id="webpush">
-  <h2><i class="fa fa-flask"></i> Web<strong>Push</strong> Server</h2>
+<article>
+  <h2 id="webpush"><i class="fa fa-flask"></i> Web<strong>Push</strong> Server</h2>
   <p>The <a href="https://tools.ietf.org/html/draft-thomson-webpush-http2">WebPush Specification</a> is based on HTTP2 and currently in an early state. The AeroGear team sees it as the successor of SimplePush.</p>
 
   <h4>Getting started</h4>
@@ -87,7 +87,7 @@ sub-section-title: AeroGear Push
 <!---------------------------------------------------->
 
 <article>
-  <h2><i class="fa fa-road"></i> RoadMap</h2>
+  <h2 id="roadmap"><i class="fa fa-road"></i> RoadMap</h2>
   <p>Upcoming releases of these three push servers are tracked in our project <a href="/docs/planning" class="btn btn-primary btn-sm"><i class="fa fa-road"></i> RoadMap</a>.</p>
 </article>
 
@@ -95,6 +95,6 @@ sub-section-title: AeroGear Push
 <!---------------------------------------------------->
 
 <article>
-  <h2><i class="fa fa-users"></i> Get Involved</h2>
+  <h2 id="get-involved"><i class="fa fa-users"></i> Get Involved</h2>
   <p>If you are interested, feel free to fork the <a href="https://github.com/aerogear" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> Repositories</a> and get your hands dirty. Also, feel free to reach out to us if you have any <a href="/community/#contact" class="btn btn-primary btn-sm"><i class="fa fa-question"></i> Questions</a></p>
 </article>

--- a/security/index.html
+++ b/security/index.html
@@ -21,5 +21,5 @@ sub-section-title: AeroGear Security
       <hr />
 
       <section>
-          <h3><i class="fa fa-paw"></i> Work in progress... <a href="https://issues.jboss.org/browse/AGSEC-200">AGSEC-200</a></h3>
+          <h2><i class="fa fa-paw"></i> Work in progress... <a href="https://issues.jboss.org/browse/AGSEC-200">AGSEC-200</a></h2>
       </section>

--- a/security/index.html
+++ b/security/index.html
@@ -18,8 +18,7 @@ sub-section-title: AeroGear Security
         <a href="{{ site.baseurl }}/OAuth2/" class="btn btn-primary btn-sm"><i class="fa fa-info"></i> More info</a>
       </p>
 
-      <hr />
 
-      <section>
-          <h2><i class="fa fa-paw"></i> Work in progress... <a href="https://issues.jboss.org/browse/AGSEC-200">AGSEC-200</a></h2>
-      </section>
+
+            <h2><i class="fa fa-paw"></i> Work in progress... <a href="https://issues.jboss.org/browse/AGSEC-200">AGSEC-200</a></h2>
+  

--- a/sync/index.markdown
+++ b/sync/index.markdown
@@ -37,18 +37,18 @@ The specification for AeroGear Data-Sync including client/server API, message fo
 Below are the various GitHub repositories that are part of the Data-Sync feature in AeroGear.
 
 
-<h4><i class="fa fa-server"></i> Data-Sync Server</h4>
+<h3><i class="fa fa-server"></i> Data-Sync Server</h3>
 
 Our Netty-based [Java Server](https://github.com/aerogear/aerogear-sync-server) exposes WebSocket and XMPP/GCM endpoint for our different clients.
 
 
-<h4><i class="fa fa-android"></i> Android</h4>
+<h3><i class="fa fa-android"></i> Android</h3>
 
 An [XMPP-client library](https://github.com/aerogear/aerogear-android-sync) to receive sync updates over GCM.
 
 
 
-<h4><i class="fa fa-apple"></i> iOS</h4>
+<h3><i class="fa fa-apple"></i> iOS</h3>
 
 For iOS we have two different libraries that are developed:
 
@@ -61,7 +61,7 @@ Besides the libraries we do already have a little [demo application](https://git
 
 
 
-<h4><i class="fa fa-html5"></i> JavaScript</h4>
+<h3><i class="fa fa-html5"></i> JavaScript</h3>
 
 The JavaScript client comes with a WebSocket-based library as well. There is also a Node.js based demo, which can be used against the above Java server.
 

--- a/sync/index.markdown
+++ b/sync/index.markdown
@@ -19,20 +19,20 @@ sub-section-title: AeroGear Sync
 Full real-time data sync where updates are initiated from both the client and server over a bi-directional channel. This feature provides both, a specific server side sync engine, as well as a client side sync engines for Android, iOS and JavaScript. The implementation is based on Google's [Differential Synchonrization](http://research.google.com/pubs/pub35605.html) by Neil Fraser.
 
 
-<h2><i class="fa fa-road"></i> RoadMap</h2>
+<h2 id="roadmap"><i class="fa fa-road"></i> RoadMap</h2>
 
 The AeroGear Data-Sync effort started out of a POC and we are now moving towards a first alpha release. 
 
 [List of sync-1.0.0.alpha.1 JIRA tickets](https://issues.jboss.org/issues/?filter=12323088)
 
 
-<h2><i class="fa fa-road"></i> Specification</h2>
+<h2 id="spec"><i class="fa fa-book"></i> Specification</h2>
 
 The specification for AeroGear Data-Sync including client/server API, message format and more can be found here:  
 [Data-Sync Specification](../docs/specs/aerogear-data-sync)
 
 
-<h2><i class="fa fa-flask"></i> Development</h2>
+<h2 id="development"><i class="fa fa-flask"></i> Development</h2>
 
 Below are the various GitHub repositories that are part of the Data-Sync feature in AeroGear.
 
@@ -69,6 +69,6 @@ Currently our JS library and demo is located [here](https://github.com/aerogear/
 
 
 
-<h2><i class="fa fa-users"></i> Get Involved</h2>
+<h2 id="get-involved"><i class="fa fa-users"></i> Get Involved</h2>
 
 If you are interested, feel free to fork the repositories and get your hands dirty. Also, feel free to reach out to us if you have any [questions](/community)!


### PR DESCRIPTION
* added ability to generate TOC (table of contents) from the generated page (H2 and H3 are considered)
  * note the change to `_layout/landing-page.html` adds TOC to all Modules and Platforms landing pages
* fixes required to TOC to work
* changes to Push Module page as requested by @matzew in the mailing list and noted in [AEROGEAR-1636](https://issues.jboss.org/browse/AEROGEAR-1636)

Fixes:
* https://issues.jboss.org/browse/AEROGEAR-1636
* https://issues.jboss.org/browse/AEROGEAR-1638

Staging deployment:
* http://staging-aerogearsite.rhcloud.com/push/