### PR TITLE
Add in the Google+ verification page

### DIFF
--- a/google57ca006da9878997.html
+++ b/google57ca006da9878997.html
@@ -1,0 +1,1 @@
+google-site-verification: google57ca006da9878997.html


### PR DESCRIPTION
Motivation:
This page will verify our website with Google and link the Google+ page and the website.  This will let information form the AeroGear Google+ page show up in the Google sidebar when people search for us.