### PR TITLE
fixed anchor scrolling / TOC behavior AEROGEAR-1624

### DIFF
--- a/_includes/sidebar-docs.html
+++ b/_includes/sidebar-docs.html
@@ -1,25 +1,14 @@
 <ul class="nav">
   <li class="active">
-    <a href="#core">AeroGear<strong>SDK</strong> Docs</a>
-    <ul>
-      <li><a href="#coreAndroid">Android</a></li>
-      <li><a href="#coreIOS">iOS</a></li>
-      <li><a href="#coreCordova">Cordova</a></li>
-      <li><a href="#coreJs">JavaScript</a></li>
-    </ul>
+    <a href="#core"><strong>SDK</strong> Docs</a>
   </li>
   <li>
-    <a href="#push">AeroGear<strong>Push</strong> Docs</a>
+    <a href="#push"><strong>Push</strong> Docs</a>
   </li>
   <li>
-    <a href="#security">AeroGear<strong>Security</strong> Specs</a>
-    <ul>
-      <li><a href="#securityOTP">Authentication</a></li>
-      <li><a href="#securityAuthentication">One-Time Password</a></li>
-      <li><a href="#securityCryptography">Cryptography</a></li>
-    </ul>
+    <a href="#security"><strong>Security</strong> Specs</a>
   </li>
   <li>
-    <a href="#sync">AeroGear<strong>Sync</strong> Specs</a>
+    <a href="#sync"><strong>Sync</strong> Specs</a>
   </li>
 </ul>

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,9 @@
 jQuery(function($){
 
-$('body').scrollspy({ target: '.sidebar' });  
+  $('body').scrollspy({
+    target: '.sidebar',
+    offset: 75
+  });
 
   $('.sidebar > .nav').affix({
     offset: {
@@ -8,12 +11,6 @@ $('body').scrollspy({ target: '.sidebar' });
           return (this.top = $(".main-banner").outerHeight(true));
         },
         bottom: 558
-//        bottom: function () {
-//          return (this.bottom = $('footer').outerHeight(true) + $('.redhat').outerHeight(true));
-//        }
-//      bottom: function () {
-//        return (this.bottom = $("footer").outerHeight(true)+$('.redhat').outerHeight(true));
-//      }
     }
   });  
 
@@ -24,54 +21,54 @@ $('body').scrollspy({ target: '.sidebar' });
           return (this.top = $(".main-banner").outerHeight(true));
         },
         bottom: 558
-//        bottom: function () {
-//          return (this.bottom = $('footer').outerHeight(true) + $('.redhat').outerHeight(true));
-//        }
-//      bottom: function () {
-//        return (this.bottom = $("footer").outerHeight(true)+$('.redhat').outerHeight(true));
-//      }
     }
   });  
 
 
+  window.showShadow = function(){
+   if($(window).scrollTop() === 0){
+          $(".navbar").css("box-shadow", "0 0 0px rgba(0,0,0,.2)");
+      }else{
+          $(".navbar").css("box-shadow", "0 0 8px rgba(0,0,0,.3)");
+      }
+  };
 
-    
-    window.showShadow = function(){    
-     if($(window).scrollTop() === 0){
-            $(".navbar").css("box-shadow", "0 0 0px rgba(0,0,0,.2)");
-        }else{
-            $(".navbar").css("box-shadow", "0 0 8px rgba(0,0,0,.3)");
-        }
-    };
-    
-    $(window).scroll(showShadow);
-    showShadow();
+  $(window).scroll(showShadow);
+  showShadow();
 
 
-
-  
-//   $('.submenu').affix({    
-//       offset: {
-//        top: function (){
-//          return (this.top = $(".main-banner").outerHeight(true));
-//        },
-//        
-//        bottom: function (){
-//          return (this.bottom = $("footer").outerHeight(true)+$('.redhat').outerHeight(true));
-//        }
-//
-//      }  
-//   });
-
-    // scroll to correct position of anchor (avoid being hidden behind navbar)
-    function scrollAnchorToView() {
-      window.scrollBy(0, -70);
+  /**
+   * scrolls to the provided anchor given by hash name (#id)
+   * @param hash the name of the anchor
+   * @returns {boolean} true if we found the element and scrolled to it
+   */
+  function scrollToHash( hash ) {
+    var targetId = hash.replace(/^#/, '');
+    if (targetId) {
+      var target = document.getElementById(targetId);
+      if (target && target.scrollIntoView) {
+        var timeout = window.requestAnimationFrame || window.setTimeout;
+        timeout(function () {
+          location.hash = targetId;
+          target.scrollIntoView(true);
+          window.scrollBy(0, -70);
+        });
+        return true;
+      }
     }
-    $(window).on('hashchange', scrollAnchorToView);
-    if (location.hash) {
-      scrollAnchorToView();
+    return false;
+  }
+
+  // scroll to correct position when clicking on anchor
+  $('body').on('click', 'a[href^="#"]', function() {
+    var result = scrollToHash( $(this).attr('href') );
+    return !result; // return false in case we were able to scroll to the element
+  });
+  // scroll to initial location hash
+  $(function() {
+    if ( location.hash ) {
+      scrollToHash( location.hash );
     }
-
-
+  });
     
 });


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-1624

* scrollspy offset: 75
* `scrollToHash` handles anchor navigation completely (as opposed to previous `onhashchange` handling)
  * avoids flickering and wrong position caused by odd timing 
* a bit of cleanup (commented things, unnecessary sidebar-docs items)

---

The correct behavior can be verified here: http://staging-aerogearsite.rhcloud.com/docs/unifiedpush/ups_userguide/index/#_running_the_unifiedpush_server_on_openshift

1. After the load, the page should be scrolled at the position of the anchor (Running UPS on OpenShift)
2. on clicking anchors (e.g. in Table of Contents sidebar), the headers that you click on should be always visible as a first element under the Top Navigation Bar