### PR TITLE
added external posts to Atom feed AEROGEAR-1608

### DIFF
--- a/feed.atom
+++ b/feed.atom
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -14,13 +14,13 @@ layout: nil
    <email>{{ site.email }}</email>
  </author>
 
- {% for post in site.posts limit 25 %}
+ {% for post in site.data['all_posts'] limit 25 %}
  <entry>
    <title>{{ post.title }}</title>
-   <link href="http://{{ site.domain }}{{ post.url }}"/>
+   <link href="{% if post.external != true %}http://{{ site.domain }}{% endif %}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>http://{{ site.domain }}{{ post.id }}</id>
-   <content type="html">{{ post.content | xml_escape }}</content>
+   <content type="html">{{ post.excerpt | markdownify | xml_escape }}</content>
  </entry>
  {% endfor %}
 


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-1608

* use `all_posts` instead of `site.posts`
* get rid of `Build Warning: Layout 'nil' requested in feed.atom does not exist.`

Generated feed: http://staging-aerogearsite.rhcloud.com/feed.atom