### PR TITLE
update links for iOS 2.2 rel.

### DIFF
--- a/_data/sdk.yml
+++ b/_data/sdk.yml
@@ -26,16 +26,16 @@ ios:
       version: 0.2
       cocoapod: aerogearhttp
       zip: https://github.com/aerogear/aerogear-ios-http/zipball/0.2.0
-      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.0/Weather
+      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.1/Weather
       guide: /docs/guides/aerogear-ios-2.X/HttpLib/
     oauth2:
       name: OAuth2
       module: security
       version: 0.2
       cocoapod: aerogearoauth2
-      zip: https://github.com/aerogear/aerogear-ios-oauth2/zipball/0.2.0
-      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.0/Shoot
-      guide: http://localhost:4000/docs/guides/aerogear-ios-2.X/Authorization/
+      zip: https://github.com/aerogear/aerogear-ios-oauth2/zipball/0.2.1
+      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.1/Shoot
+      guide: /docs/guides/aerogear-ios-2.X/Authorization/
     push:
       name: Push
       module: push
@@ -43,15 +43,30 @@ ios:
       cocoapod: AeroGear-Push
       zip: https://github.com/aerogear/aerogear-ios-push/archive/1.0.0-swift.zip
       demo: https://github.com/aerogear/aerogear-push-helloworld/tree/swift/ios-swift
-      guide: http://localhost:4000/docs/unifiedpush/aerogear-push-ios/
+      guide: /docs/unifiedpush/aerogear-push-ios/
     jsonsz:
       name: JSON Serialization
       module: core
       version: 0.1
       cocoapod: aerogearjsonsz
       zip: https://github.com/aerogear/aerogear-ios-jsonsz/zipball/0.1.0
-      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.0/Buddies
+      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.1/Buddies
       guide: /docs/guides/aerogear-ios-2.X/JsonSZ/
+    sync:
+      name: Sync
+      module: sync
+      version: 1.0.0-alpha.1
+      cocoapod: aerogearsync
+      zip: https://github.com/aerogear/aerogear-ios-sync/zipball/1.0.0-alpha.1
+      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.1/Jedi
+    sync-client:
+      name: Sync-Client
+      module: sync
+      version: 1.0.0-alpha.1
+      cocoapod: aerogearsyncclient
+      zip: https://github.com/aerogear/aerogear-ios-sync-client/zipball/1.0.0-alpha.1
+      demo: https://github.com/aerogear/aerogear-ios-cookbook/tree/0.2.1/Jedi
+
 
 cordova:
   name: Cordova

--- a/ios/index.md
+++ b/ios/index.md
@@ -52,6 +52,11 @@ section: platforms
 [aerogear-ios-push](https://github.com/aerogear/aerogear-ios-push/) is a small and handy library written in Swift that helps to register iOS applications with the AeroGear UnifiedPush Server.
 {% when 'jsonsz' %}
 [aerogear-ios-jsonsz](https://github.com/aerogear/aerogear-ios-jsonsz/) serializes 'Swift' objects back-forth from their JSON representation the 'easy way'.
+{% when 'sync' %}
+[aerogear-ios-sync](https://github.com/aerogear/aerogear-ios-sync/)  an iOS Sync Engine for AeroGear Differential Synchronization server
+{% when 'sync-client' %}
+[aerogear-ios-sync-client](https://github.com/aerogear/aerogear-ios-sync-client/) a client side implementation for AeroGear Differential Synchronization server based on websockets
+
 {% endcase %}
 {% endcapture %}
 <!-- END DESCRIPTION -->

--- a/sync/index.markdown
+++ b/sync/index.markdown
@@ -16,7 +16,7 @@ sub-section-title: AeroGear Sync
   </p>
 
 
-Full real-time data sync where updates are initiated from both the client and server over a bi-directional channel. This feature provides a specific server side sync engine, as well as a client side sync engines for Android, iOS and JavaScript. The implementation is based on Google's [Differential Synchonrization](http://research.google.com/pubs/pub35605.html) by Neil Fraser.
+Full real-time data sync where updates are initiated from both the client and server over a bi-directional channel. This feature provides both, a specific server side sync engine, as well as a client side sync engines for Android, iOS and JavaScript. The implementation is based on Google's [Differential Synchonrization](http://research.google.com/pubs/pub35605.html) by Neil Fraser.
 
 
 <h3 id="sync-in-action">See it in Action</h3>
@@ -64,7 +64,7 @@ For iOS we have two different libraries that are developed:
 
 The initial releases of the libraries are available on [CocoaPods](http://cocoapods.org/?q=AeroGearSync) as well.
 
-Besides the libraries we do already have a little [demo application](https://github.com/aerogear/aerogear-ios-sync-demo), which can be used against the above Java server.
+Besides the libraries we do already have a little [demo application](https://github.com/aerogear/aerogear-ios-cookbook/tree/master/Jedi) on our [Cookbook example repository](https://github.com/aerogear/aerogear-ios-cookbook#), which can be used against the above Java server.
 
 
 


### PR DESCRIPTION
update links for iOS 2.2 release.

its the same as the [PR#541](https://github.com/aerogear/aerogear.org/pull/541) but opened against "```master```" now instead of "```new-design```"


@corinnekrych mind to review? I will merge afterwards in master/production branches