### PR TITLE
Improve steps to build AGDroid libraries

### DIFF
--- a/docs/guides/aerogear-android/how-to-build-aerogear-android.asciidoc
+++ b/docs/guides/aerogear-android/how-to-build-aerogear-android.asciidoc
@@ -28,28 +28,8 @@ cd $PWD/maven-android-sdk-deployer/platforms/android-22
 mvn install -N --quiet
 ```
 
-=== Install locally google-play-services
-```
-cd $PWD/maven-android-sdk-deployer/extras/google-play-services
-mvn  install -N --quiet
-```
-
-=== Install locally compatibility-v4
-```
-cd $PWD/maven-android-sdk-deployer/extras/compatibility-v4
-mvn install -N --quiet
-```
-
-=== Install locally compatibility-v7-appcompat
-```
-cd $PWD/maven-android-sdk-deployer/extras/compatibility-v7-appcompat
-mvn install -N --quiet
-```
-
-=== Install locally repositories
+=== Install locally Android and Google libraries 
 ```
 cd $PWD/maven-android-sdk-deployer/repositories
-mvn install -N --quiet
+mvn install --quiet
 ```
-
-


### PR DESCRIPTION
## Why?

* _Google Play Services_ now is part of _repositories_ 
* _compatibility-v4_ and _compatibility-v7-appcompat_ are using only in or example apps. Since all of our examples are gradle projects, it's not necessarily anymore

## How test it?

I think the best way is:

* `rm -rf ~/.m2`
* Build [aerogear-android-push](https://github.com/aerogear/aerogear-android-push/)
* Cross finger