### PR TITLE
fixed versions and ids of cordova plugins

### DIFF
--- a/_data/sdk.yml
+++ b/_data/sdk.yml
@@ -94,31 +94,31 @@ cordova:
       long-name: Push
       module: push
       version: latest
-      plugin: org.jboss.aerogear.cordova.push
+      plugin: aerogear-cordova-push
     otp:
       name: OTP
       long-name: OTP (One-Time Password)
       module: security
       version: latest
-      plugin: org.jboss.aerogear.cordova.otp
+      plugin: aerogear-cordova-otp
     crypto:
       name: Crypto
       long-name: Crypto
       module: security
-      version: 0.0.1
-      plugin: org.jboss.aerogear.cordova.crypto
+      version: latest
+      plugin: aerogear-cordova-crypto
     geo:
       name: Geo
       long-name: Geofencing
       module: geo
       version: latest
-      plugin: org.jboss.aerogear.cordova.geo
+      plugin: aerogear-cordova-geo
     oauth2:
       name: OAuth2
       long-name: OAuth2
       module: security
       version: latest
-      plugin: org.jboss.aerogear.cordova.oauth2
+      plugin: aerogear-cordova-oauth2
 
 windows:
   name: Windows

--- a/_includes/downloads/cordova-plugin.html
+++ b/_includes/downloads/cordova-plugin.html
@@ -2,7 +2,7 @@
 {% assign module = include.module %}
 <p>
   <a href="https://github.com/aerogear/aerogear-{{ moduleName }}-cordova/releases/{{ module.version }}" class="btn btn-primary-inverse"><i class="fa fa-cloud-download"></i> Download {{ module.name }} Plugin</a>
-  <a href="http://plugins.cordova.io/#/package/{{ module.plugin }}" class="btn btn-primary btn-sm"><i class="fa fa-cubes"></i> Plugin Registry</a>
-  <a href="https://github.com/aerogear/aerogear-{{ moduleName }}-cordova/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> View the Source</a>
+  <a href="https://www.npmjs.com/package/{{ module.plugin }}" class="btn btn-primary btn-sm"><i class="fa fa-cubes"></i> Plugin Registry</a>
+  <a href="https://github.com/aerogear/aerogear-cordova-{{ moduleName }}/" class="btn btn-primary btn-sm"><i class="fa fa-github-alt"></i> View the Source</a>
   <span class="label label-default cordovaplugin" contenteditable="true" readonly="readonly"><span contenteditable="false">{{ module.plugin }}</span></span>
 </p>

--- a/cordova/index.md
+++ b/cordova/index.md
@@ -12,7 +12,7 @@ section: platforms
   <p>
     <a href="/getstarted/guides/" class="btn btn-primary"><i class="fa fa-book"></i> Guides</a>
     <a href="/getstarted/demos/#cordova" class="btn btn-primary"><i class="fa fa-cogs"></i> Demos</a>
-    <a href="http://localhost:4000/docs/specs/aerogear-cordova/" class="btn btn-primary"><i class="fa fa-file-text-o"></i> API Documentation</a>
+    <a href="/docs/specs/aerogear-cordova/" class="btn btn-primary"><i class="fa fa-file-text-o"></i> API Documentation</a>
     <a href="https://github.com/aerogear/?query=cordova" class="btn btn-primary"><i class="fa fa-github-alt"></i> GitHub Repos</a>
   </p>
 


### PR DESCRIPTION
@matzew plugins are no longer called org.jboss.aerogear.cordova.<plugin name> but aerogear-cordova-<plugin name> this PR changes that on the site as well.