### PR TITLE
Added a different section for downloading application server for Unif…

### DIFF
--- a/docs/unifiedpush/ups_userguide/server-installation.asciidoc
+++ b/docs/unifiedpush/ups_userguide/server-installation.asciidoc
@@ -14,7 +14,12 @@ Getting the UnifiedPush Server up and running with an on-premise application ser
 . <<schema,Create the database schema>>
 . <<deploy,Deploy the UnifiedPush Server>>
 
-Each of these steps is detailed here, with instructions and useful scripts provided for the supported databases (MySQL, PostgreSQL) and application servers (link:http://jbossas.jboss.org/downloads/[EAP 6.4.0 GA], link:http://wildfly.org/downloads/[WildFly 8.x]). __Make sure to run them in the **full-profile** mode as discussed below!__
+Each of these steps is detailed here, with instructions and useful scripts provided for the supported databases (MySQL, PostgreSQL) and application servers. __Make sure to run them in the **full-profile** mode as discussed below!__
+
+Find below the required application server version:
+
+* UnifiedPush Server version 1.1.x - link:https://developers.redhat.com/products/eap/download/[EAP 6.4.0 GA]or link:http://wildfly.org/downloads/[WildFly 8.x]
+* UnifiedPush Server 1.2.x - link:https://developers.redhat.com/products/eap/download/[EAP 7.x] or link:http://wildfly.org/downloads/[WildFly 10.x]
 
 NOTE: You can also link:#openshift[run the UnifiedPush Server in the cloud with OpenShift] but this requires a different setup process.
 
@@ -24,7 +29,7 @@ The UnifiedPush Server application is provided in two files: +unifiedpush-server
 
 Download the latest copies of these files using the following link:
 
-* link:https://github.com/aerogear/aerogear-unifiedpush-server/releases/latest[Download UnifiedPush Server Release Bundle]
+* link:https://github.com/aerogear/aerogear-unifiedpush-server/releases/tag/1.1.3.Final[Download UnifiedPush Server Release Bundle]
 
 Different files are provided for each application servers:
 


### PR DESCRIPTION
# Motivation
Currently, the download link in the installation instruction was pointing to the latest release (currently an alpha one): user will probably want to download the stable one
Moreover, there was no mention of the fact that UnifiedPush Server 1.2.x requires Wildfly 10.x instead of 8.x (as documented for UnifiedPush Server 1.1.x)

# Changes
Added a new section describing the different Application Server versions required by the different UnifiedPush Server versions
Changed the download link to point to version 1.1.3Final
