### PR TITLE
AGDIGGER-176 Document using specific versions of platforms

### DIFF
--- a/docs/digger/developer/jenkinsfile-create.asciidoc
+++ b/docs/digger/developer/jenkinsfile-create.asciidoc
@@ -144,6 +144,39 @@ node("android"){
 }
 ----
 
+
+==== Using specific versions of Android SDK and Gradle
+
+Android SDK and Gradle versions are defined in the Android project.
+
+To change Android SDK version change the version information in app's `app/build.gradle.file`:
+[source,groovy]
+----
+android {
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
+
+    defaultConfig {
+        ...
+        minSdkVersion 16
+        targetSdkVersion 25
+        ...
+    }
+...
+}
+----
+
+See https://developer.android.com/studio/build/index.html[Android platform documents] for
+explanation of these properties.
+
+To change Gradle version, change the `distributionUrl` property in `gradle/wrapper/gradle-wrapper.properties`
+in the app's source tree.
+[source,properties]
+----
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+----
+
+
 === Signing the Application
 
 ==== Signing Android build
@@ -206,7 +239,7 @@ storing in the same directory.
 
 
 
-The funtion takes the following parameters.
+The function takes the following parameters.
 
 [[building-with-xcode]]
 ==== Building with xCode Parameters


### PR DESCRIPTION
Document using specific versions of platforms.

JIRA: https://issues.jboss.org/browse/AGDIGGER-176

I only added new documentation to AeroGear.org docs. Any other place didn't make sense as Xcode version is documented inline in Digger-Jenkins sample IOS Jenkinsfile and Android things are in template apps.

Here we have documented how to use a specific XCode version already:
https://github.com/aerogear/aerogear.org/blob/a5d6601de30f0d014721056ac666ef318c72dcc4/docs/digger/developer/jenkinsfile-create.asciidoc#building-applications-with-xcode

Android specific things are explained in the PR.

@finp @pmacko1 may I have your quick review too?