### PR TITLE
Use system font stack

### DIFF
--- a/css/styles.less
+++ b/css/styles.less
@@ -6,12 +6,13 @@
  */
 
 // Core
-
 @import "bower_components/bootstrap/less/bootstrap.less";
 
 // Font
-@import url(//fonts.googleapis.com/css?family=Open+Sans:700,600,300,400);
-@font-family-sans-serif: 'Open Sans', sans-serif;
+@font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+@font-size-base: 16px;
+@font-size-large: 20px;
+
 
 @font-weight-light: 300;
 @font-weight-regular: 400;


### PR DESCRIPTION
## Description
- Increase font size for improved legibility 
- Update font stack to use native fonts. This should increase readability, load time performance, user experience across devices and font rendering.

For iOS and El Capitan and above on Mac this will default to San Francisco. For Android and Fedora it will default to Roboto. 

## High Sierra
<img width="493" alt="screen shot 2018-06-13 at 21 44 48" src="https://user-images.githubusercontent.com/8274693/41401428-bdddfddc-6fb7-11e8-8368-d86a45957119.png">
<img width="548" alt="screen shot 2018-06-13 at 21 46 17" src="https://user-images.githubusercontent.com/8274693/41401427-bdc50c14-6fb7-11e8-8c32-d295a1dc82b4.png">

With paragraph text (before and after):

<img width="795" alt="screen shot 2018-06-13 at 21 51 10" src="https://user-images.githubusercontent.com/8274693/41401424-bd87dba0-6fb7-11e8-9833-84236bbb5a25.png">
<img width="789" alt="screen shot 2018-06-13 at 21 50 37" src="https://user-images.githubusercontent.com/8274693/41401425-bda99cfe-6fb7-11e8-9311-c57335bdf6cc.png">

## Fedora 27
![screenshot from 2018-06-14 09-48-04](https://user-images.githubusercontent.com/8274693/41401623-388e1d6e-6fb8-11e8-8065-7df532ff63b4.png)
![screenshot from 2018-06-14 09-30-19](https://user-images.githubusercontent.com/8274693/41401568-16441150-6fb8-11e8-9bc1-032bca764252.png)

