### PR TITLE
template news article for conferences

### DIFF
--- a/_posts/2018-07-09-conference-talks-mobile-services.md
+++ b/_posts/2018-07-09-conference-talks-mobile-services.md
@@ -10,5 +10,10 @@ Following on from the announcment about the first release of AeroGear Mobile Ser
 
 You can find us at:
 
-TODO: add any conference you are confirmed attending to talk about Mobile Services here.
+* [Dev Conf US - August 2018](https://devconfus2018.sched.com/event/FNMK/calling-serverless-functions-from-an-android-app){:target="_blank"}
+	* Peter Braun and David Martin
+	* Calling serverless functions from an android app
 
+* [Connect.tech - October 2018](http://connect.tech){:target="_blank"}
+	* Summers Pittman
+	* Using bots, containers, and mobile technologies to respond to events

--- a/_posts/2018-07-09-conference-talks-mobile-services.md
+++ b/_posts/2018-07-09-conference-talks-mobile-services.md
@@ -1,0 +1,14 @@
+---
+layout: news
+section: news
+title: Where you can find talks on AeroGear Mobile Services!
+author: aerogear
+tag: community
+---
+
+Following on from the announcment about the first release of AeroGear Mobile Services on OpenShift we'll be hitting up a few conferences to talk about it some more.
+
+You can find us at:
+
+TODO: add any conference you are confirmed attending to talk about Mobile Services here.
+


### PR DESCRIPTION
**What**
Add a news article template for listing call for conferences and conferences confirmed attended by any member of the AeroGear team where Mobile Services is the topic.

**Why**
Following on from a discussion in the AeroGear Community Meeting we decided to take an [action](https://trello.com/c/J4YyUWXb/36-create-a-list-of-conferences-events-where-we-can-go-and-present-aerogear-mobile-services) to list upcoming conferences in one place

@johnfriz 

![image](https://user-images.githubusercontent.com/6498727/42462424-23a3f31e-839b-11e8-9b21-771a44f35888.png)
