### PR TITLE
remove sdk links from fotter

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,9 +2,13 @@
   <div class="container">
     <div class="row">
 
+      <div class="col-sm-1">
+
+      </div><!-- col -->
+
       <div class="col-sm-4">
-        <h5>Mobile Services</h5>
-        <ul class="list-unstyled">
+        <h5 class="text-center">Mobile Services</h5>
+        <ul class="text-center list-unstyled">
           <li><a href="/services/identity-management/">Identity Management</a></li>
           <li><a href="/services/push/">Push Notifications</a></li>
           <li><a href="/services/runtime-connector/">Runtime Connector</a></li>
@@ -14,19 +18,13 @@
         </ul>
       </div><!-- col -->
 
-      <div class="col-sm-4">
-        <h5>Mobile SDKs</h5>
-        <ul class="list-unstyled">
-         <li><a href="/sdks/android/">Android</a></li>
-         <li><a href="/sdks/cordova/">Cordova</li>
-         <li><a href="/sdks/ios/">iOS</a></li>
-         <li><a href="/sdks/xamarin/">Xamarin</a></li>
-        </ul>
+      <div class="col-sm-2">
+
       </div><!-- col -->
 
       <div class="col-sm-4">
-        <h5>COMMUNITY</h5>
-        <ul class="list-unstyled">
+        <h5 class="text-center">COMMUNITY</h5>
+        <ul class="text-center list-unstyled">
           <li><a target="_blank" href="https://github.com/aerogear/">GitHub - Aerogear</a></li>
           <li><a target="_blank" href="https://github.com/aerogearcatalog/">GitHub - Aerogear Catalog</a></li>
           <li><a target="_blank" href="https://issues.jboss.org/browse/AEROGEAR">Jira Repo Issues</a></li>
@@ -34,6 +32,10 @@
           <li><a target="_blank" href="https://groups.google.com/forum/#!forum/aerogear">Google Group</a></li>
           <li><a href="irc://irc.freenode.net/aerogear">IRC</a></li>
         </ul>
+      </div><!-- col -->
+
+      <div class="col-sm-1">
+
       </div><!-- col -->
 
       <div class="col-sm-12 follow">


### PR DESCRIPTION
**What**
Remove the SDK Links from the footer
Centre the text

**Why**
The links don't go anywhere
We have a link in the top nav already for the main SDK table page
**Before**
![image](https://user-images.githubusercontent.com/6498727/42825924-0d5e2624-89db-11e8-8d6e-06f995edeff6.png)

**After**
![image](https://user-images.githubusercontent.com/6498727/42825904-fd085e8e-89da-11e8-9835-068b7d68f8c7.png)
