### PR TITLE
Add community meeting information to the community page

### DIFF
--- a/_includes/sidebar-community.html
+++ b/_includes/sidebar-community.html
@@ -8,6 +8,10 @@
   </li>
 
   <li>
+    <a href="#community-meeting">Community Meeting</a>
+  </li>
+
+  <li>
     <a href="#guides">Contributing to AeroGear</a>                  
   </li>
 

--- a/community/contributingGuides/Contributing.asciidoc
+++ b/community/contributingGuides/Contributing.asciidoc
@@ -31,7 +31,7 @@ We only ask that you review our link:../JIRAUsage[AeroGear Jira Usage and Guidel
 ==== Fix an Issue!
 Your ready to start taking action, dig into an issue, and update some code! Excellent!!
 
-*Communicate*
+==== Communicate
 
 The first recommended step is to communicate with the project team. This way you can get any advice, or feedback on your plans.
 

--- a/community/index.html
+++ b/community/index.html
@@ -34,6 +34,17 @@ section: community
             <a href="https://github.com/orgs/aerogear/people" class="btn btn-primary"><i class="fa fa-users"></i> AeroGear contributors</a>
           </p>
         </article><!-- team -->
+
+
+        <article id="community-meeting">
+          <h2 class="section-header">Community Meeting</h2>
+          <p>The AeroGear community meeting is a public and recorded event which occurs every <b>Monday</b> at <b>3pm Irish Standard Time (IST)</b>. </p>
+          <p>
+            The meetings can be found on the <a target="_blank" href="https://calendar.google.com/calendar?cid=MG83ZmprYnJrYXRhcHJra3RubnMxMjRtajRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">AeroGear calendar</a>. 
+            All community meeting announcements or updates will be communicated through this calendar and the <a href="#mailing-lists">AeroGear mailing list</a>.
+          </p>
+          <p> Recordings of previous AeroGear community meetings are archived on the <a target="_blank" href="https://trello.com/c/4ogUlVT8/15-meeting-summaries">AeroGear Community Trello Board</a>.</p>
+        </article>
      
         
         <article id="contact">

--- a/community/index.html
+++ b/community/index.html
@@ -40,10 +40,10 @@ section: community
           <h2 class="section-header">Community Meeting</h2>
           <p>The AeroGear community meeting is a public and recorded event which occurs every <b>Monday</b> at <b>3pm Irish Standard Time (IST)</b>. </p>
           <p>
-            The meetings can be found on the <a target="_blank" href="https://calendar.google.com/calendar?cid=MG83ZmprYnJrYXRhcHJra3RubnMxMjRtajRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">AeroGear calendar</a>. 
+            The meetings can be found on the <a href="/community/contributingGuides/Contributing#_communicate">AeroGear calendar</a>. 
             All community meeting announcements or updates will be communicated through this calendar and the <a href="#mailing-lists">AeroGear mailing list</a>.
           </p>
-          <p> Recordings of previous AeroGear community meetings are archived on the <a target="_blank" href="https://trello.com/c/4ogUlVT8/15-meeting-summaries">AeroGear Community Trello Board</a>.</p>
+          <p> Recordings of previous AeroGear community meetings are archived on the <a target="_blank" href="https://www.youtube.com/playlist?list=PLrb9Md9fGqvnAzWd2bcQdH9i3l1ba4RFT">AeroGear Youtube channel</a>.</p>
         </article>
      
         


### PR DESCRIPTION
## Description
Add a section for the community meeting information in the community page. This change is a follow up on discussions from the community meeting.

## Progress
- [x] Add section for the community meeting in the community page.
- [x] Add a link to the Aerogear calendar.
- [x] Add a link to the archived community meeting recordings.

## Additional Notes
[Trello Card](https://trello.com/c/9RLyT77G/52-add-the-community-meeting-recordings-to-aerogearorg)

**Screenshot**
![image](https://user-images.githubusercontent.com/9078522/43395053-a3bf0fc0-93f4-11e8-88dd-05bd027777ad.png)
