### PR TITLE
remove reference to staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Before you can run the site, make sure you have [asciidoc](http://www.methods.co
 
 ## Running locally
 
-Ruby & its ecosystem is difficult to install and manage, so we recommend running Jekyll & aerogear.org in via Docker.
+Ruby & its ecosystem is difficult to install and manage, so we recommend running Jekyll & aerogear.org via Docker.
 
 ### Building
 
@@ -29,13 +29,10 @@ docker run --rm -it -p 4000:4000 -v `pwd`:/home/aerogear/aerogear aerogear.org
 This will setup a watch locally, and serve content locally via http://localhost:4000
 
 
-### Deploying Changes
+### Publishing Changes
 
 1. Make changes in aerogear.org repo on a custom branch
 1. Create a PR against the `master` branch
 1. Get the changes reviewed and verified
 1. Merge to the `master` branch
-1. Contact a team member on #aerogear on irc to trigger the build to publish the `master` branch to https://staging.aerogear.org
-1. Get the changes verified
-1. Merge to the `production` branch
-1. Contact a team member on #aerogear on irc to trigger the build to publish the `production` branch to to https://aerogear.org
+1. Contact a team member on #aerogear on irc to trigger the build to publish the `master` branch to https://aerogear.org

--- a/publish-staging.sh
+++ b/publish-staging.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-#scp -r _site/ aerogear@filemgmt.jboss.org:/stg_htdocs/aerogear
-rsync -vr _site/ aerogear@filemgmt.jboss.org:/stg_htdocs/aerogear

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-#scp -r _site/ aerogear@filemgmt.jboss.org:/www_htdocs/aerogear
 rsync -r _site/ aerogear@filemgmt.jboss.org:/www_htdocs/aerogear


### PR DESCRIPTION
**What**
Simplify the process of publishing the site.

**Why**
The staging site is public, the main site is updated regularly and it's possible to build and verify changes to the site locally before merging the changes to master so there is no need to have the step of publishing to staging. 

**Proposal**
[Proposal](https://groups.google.com/forum/#!searchin/aerogear/staging%7Csort:date/aerogear/-D3DDxUC-cM/afUF0fXEDwAJ)