### PR TITLE
Remove runtime connector

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -24,17 +24,6 @@ push:
   documentation: https://docs.aerogear.org/aerogear/latest/push-notifications.html
   github: https://github.com/aerogearcatalog/unified-push-apb/
 
-conector:
-  name: Runtime Connector
-  icon: cloud
-  link: /services/runtime-connector/
-  description: Connect your mobile apps to your own backend API servers
-  features: 
-    - Bind your mobile client to custom backend API services and business logic
-    - Add custom configuration for a backend service, which becomes accessible from your Mobile App
-  documentation: https://docs.aerogear.org/aerogear/latest/runtime-connector.html
-  github: http://github.com/aerogearcatalog/custom-runtime-connector-apb/
-
 metrics:
   name: Mobile Metrics
   icon: insert_chart

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,12 +9,9 @@
       <div class="col-sm-4">
         <h5 class="text-center">Mobile Services</h5>
         <ul class="text-center list-unstyled">
-          <li><a href="/services/identity-management/">Identity Management</a></li>
-          <li><a href="/services/push/">Push Notifications</a></li>
-          <li><a href="/services/runtime-connector/">Runtime Connector</a></li>
-          <li><a href="/services/metrics/">Mobile Metrics</a></li>
-         <li><a href="/services/mobile-ci-cd/">Mobile CI/CD</a></li>
-         <li><a href="/services/device-security/">Device Security</a></li>
+          {% for service in site.data.services %}
+          <li><a href="{{ service[1].link }}">{{ service[1].name }}</a></li>
+          {% endfor %}
         </ul>
       </div><!-- col -->
 

--- a/index.html
+++ b/index.html
@@ -81,12 +81,6 @@ section: homepage
               </a>
             </th>
             <th class="text-center service-heading">
-              <a href="/services/runtime-connector/">
-                <i class="material-icons" aria-hidden="true">cloud</i>
-                <div>Runtime Connector</div>
-              </a>
-            </th>
-            <th class="text-center service-heading">
               <a href="/services/metrics/">
                 <i class="material-icons" aria-hidden="true">insert_chart</i>
                 <div>Mobile Metrics</div>
@@ -103,9 +97,6 @@ section: homepage
           <td class="text-right">
             <a href="https://docs.aerogear.org/aerogear/latest/mobile-clients.html#android">Android
             <i class="fa fa-android"></i></a>
-          </td>
-          <td class="text-center">
-            <i class="fa fa-check-square"></i>
           </td>
           <td class="text-center">
             <i class="fa fa-check-square"></i>
@@ -137,17 +128,11 @@ section: homepage
           <td class="text-center">
             <i class="fa fa-check-square"></i>
           </td>
-          <td class="text-center">
-            <i class="fa fa-check-square"></i>
-          </td>
         </tr>
         <tr>
           <td class="text-right">
             <a href="https://docs.aerogear.org/aerogear/latest/mobile-clients.html#ios">iOS
             <i class="fa fa-apple"></i></a>
-          </td>
-          <td class="text-center">
-            <i class="fa fa-check-square"></i>
           </td>
           <td class="text-center">
             <i class="fa fa-check-square"></i>
@@ -171,9 +156,6 @@ section: homepage
             <i class="fa fa-check-square"></i>
           </td>
           <td class="text-center">
-          </td>
-          <td class="text-center">
-            <i class="fa fa-check-square"></i>
           </td>
           <td class="text-center">
             <i class="fa fa-check-square"></i>

--- a/sdks/index.html
+++ b/sdks/index.html
@@ -33,12 +33,6 @@ section: sdks
             </a>
           </th>
           <th class="text-center service-heading">
-            <a href="/services/runtime-connector/">
-              <i class="material-icons" aria-hidden="true">cloud</i>
-              <div>Runtime Connector</div>
-            </a>
-          </th>
-          <th class="text-center service-heading">
             <a href="/services/metrics/">
               <i class="material-icons" aria-hidden="true">insert_chart</i>
               <div>Mobile Metrics</div>
@@ -55,9 +49,6 @@ section: sdks
         <td class="text-right">
           <a href="https://docs.aerogear.org/aerogear/latest/mobile-clients.html#android">Android
           <i class="fa fa-android"></i></a>
-        </td>
-        <td class="text-center">
-          <i class="fa fa-check-square"></i>
         </td>
         <td class="text-center">
           <i class="fa fa-check-square"></i>
@@ -89,17 +80,11 @@ section: sdks
         <td class="text-center">
           <i class="fa fa-check-square"></i>
         </td>
-        <td class="text-center">
-          <i class="fa fa-check-square"></i>
-        </td>
       </tr>
       <tr>
         <td class="text-right">
           <a href="https://docs.aerogear.org/aerogear/latest/mobile-clients.html#ios">iOS
           <i class="fa fa-apple"></i></a>
-        </td>
-        <td class="text-center">
-          <i class="fa fa-check-square"></i>
         </td>
         <td class="text-center">
           <i class="fa fa-check-square"></i>
@@ -130,9 +115,7 @@ section: sdks
         <td class="text-center">
           <i class="fa fa-check-square"></i>
         </td>
-        <td class="text-center">
-          <i class="fa fa-check-square"></i>
-        </td>
+
       </tr>
     </table>
   </div>


### PR DESCRIPTION
**What**
Remove custom runtime connector from the site
- From SDK Tables
- From Footer
- Refactor some code to use services data

Can do
- Refactor code so that SDK tables can use data which means easier to update the two locations