### PR TITLE
Remove native

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -6,7 +6,7 @@ section: getting-started
 
 <article id="overview">
   <h2 class="section-header">Introduction</h2>
-  <p>AeroGear provides a suite of Mobile Services across a range of native client SDKs that will simplify your mobile and modern application development needs, leveraging OpenShift's Container technology to provide a secure, scalable backend platform.</p>
+  <p>AeroGear provides a suite of Mobile Services across a range of client SDKs that will simplify your mobile and modern application development needs, leveraging OpenShift's Container technology to provide a secure, scalable backend platform.</p>
 
   <p>These Services can be provisioned on demand from the OpenShift Service Catalog and allow developers to address a set of common mobile development challenges with minimal overhead. Each Service has a corresponding SDK module which is imported into your mobile app. These SDK modules provide connectivity to your back end services on OpenShift and perform the "heavy lifting" - allowing developers to focus on the business value of their mobile apps.</p>
 


### PR DESCRIPTION
We support native and cross-platform element.
Suggestion from the product was to remove `native` part as it can be misleading.